### PR TITLE
Add filtering by origin, roast and tags

### DIFF
--- a/data.json
+++ b/data.json
@@ -61,7 +61,10 @@
       }
     ],
     "AverageRating": 0,
-    "RatingCount": 0
+    "RatingCount": 0,
+    "Origin": "Italy",
+    "Roast": "medium",
+    "Tags": ["Italian", "smooth"]
   },
   {
     "Bean": "Lavazza Oro",
@@ -111,7 +114,10 @@
       }
     ],
     "AverageRating": 0,
-    "RatingCount": 0
+    "RatingCount": 0,
+    "Origin": "Italy",
+    "Roast": "medium",
+    "Tags": ["fruity", "floral"]
   },
   {
     "Bean": "Lavazza Espresso",
@@ -161,7 +167,10 @@
       }
     ],
     "AverageRating": 0,
-    "RatingCount": 0
+    "RatingCount": 0,
+    "Origin": "Italy",
+    "Roast": "dark",
+    "Tags": ["bold", "rich"]
   },
   {
     "Bean": "Starbucks Espresso Roast",
@@ -211,7 +220,10 @@
       }
     ],
     "AverageRating": 0,
-    "RatingCount": 0
+    "RatingCount": 0,
+    "Origin": "United States",
+    "Roast": "dark",
+    "Tags": ["caramel", "espresso"]
   },
   {
     "Bean": "Costa Coffee Barista Blend",
@@ -261,6 +273,9 @@
       }
     ],
     "AverageRating": 0,
-    "RatingCount": 0
+    "RatingCount": 0,
+    "Origin": "United Kingdom",
+    "Roast": "medium",
+    "Tags": ["chocolate", "nuts"]
   }
 ]

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -6,29 +6,47 @@
     <title>BrewCode - Landing Page</title>
     <link rel="stylesheet" href="style.css" />
   </head>
-  <body> 
+  <body>
     <header>
-      <div class="header-box"> <!-- Header Box-->
-        <h1 id="BrewCodeTitle"> <!-- Title-->
+      <div class="header-box">
+        <!-- Header Box-->
+        <h1 id="BrewCodeTitle">
+          <!-- Title-->
           <a href="https://timmoel.github.io/Brewcode/" class="site-title">
             BrewC
-            <img src="https://static.thenounproject.com/png/120176-200.png" alt="Coffee Icon" class="icon">
+            <img
+              src="https://static.thenounproject.com/png/120176-200.png"
+              alt="Coffee Icon"
+              class="icon"
+            />
             de
           </a>
         </h1>
-        <p id="Sub-Title">Brew Your Perfect Cup</p> <!-- Subtitle-->
+        <p id="Sub-Title">Brew Your Perfect Cup</p>
+        <!-- Subtitle-->
       </div>
     </header>
-    
+
     <main>
       <div class="coffee-bean-search">
         <label for="coffeeSearch">Enter Your Coffee Bean Name</label>
-        <input
-          id="coffeeSearch"
-          type="text"
-          placeholder="e.g., Lavazza"
-        />
+        <input id="coffeeSearch" type="text" placeholder="e.g., Lavazza" />
         <button id="searchButton">Search</button>
+        <label for="originSelect">Origin:</label>
+        <select id="originSelect">
+          <option value="">All Origins</option>
+        </select>
+        <label for="roastSelect">Roast:</label>
+        <select id="roastSelect">
+          <option value="">Any Roast</option>
+          <option value="light">Light</option>
+          <option value="medium">Medium</option>
+          <option value="dark">Dark</option>
+        </select>
+        <div id="tagFilters">
+          <span>Tags:</span>
+          <div id="tagContainer"></div>
+        </div>
       </div>
     </main>
 
@@ -38,33 +56,86 @@
       // Load coffee data on page load
       window.onload = async () => {
         try {
-          const response = await fetch('data.json'); // Load local JSON file
+          const response = await fetch("data.json"); // Load local JSON file
           coffeeData = await response.json();
-          console.log('Coffee data loaded:', coffeeData);
+          populateFilters();
+          console.log("Coffee data loaded:", coffeeData);
         } catch (error) {
-          console.error('Error loading coffee data:', error);
+          console.error("Error loading coffee data:", error);
         }
       };
 
+      function populateFilters() {
+        const originSelect = document.getElementById("originSelect");
+        const tagContainer = document.getElementById("tagContainer");
+        const origins = [...new Set(coffeeData.map((b) => b.Origin))];
+        origins.forEach((origin) => {
+          const opt = document.createElement("option");
+          opt.value = origin;
+          opt.textContent = origin;
+          originSelect.appendChild(opt);
+        });
+        const tags = [...new Set(coffeeData.flatMap((b) => b.Tags))];
+        tags.forEach((tag) => {
+          const label = document.createElement("label");
+          const cb = document.createElement("input");
+          cb.type = "checkbox";
+          cb.value = tag;
+          label.appendChild(cb);
+          label.appendChild(document.createTextNode(tag));
+          tagContainer.appendChild(label);
+        });
+      }
+
       // Search button event listener
-      document.getElementById('searchButton').addEventListener('click', () => {
-        const searchQuery = document.getElementById('coffeeSearch').value.trim().toLowerCase();
+      document.getElementById("searchButton").addEventListener("click", () => {
+        const searchQuery = document
+          .getElementById("coffeeSearch")
+          .value.trim()
+          .toLowerCase();
+        const selectedOrigin = document.getElementById("originSelect").value;
+        const selectedRoast = document.getElementById("roastSelect").value;
+        const selectedTags = Array.from(
+          document.querySelectorAll("#tagContainer input:checked"),
+        ).map((cb) => cb.value);
 
         if (!searchQuery) {
-          alert('Please enter a coffee bean name!');
+          alert("Please enter a coffee bean name!");
           return;
         }
 
-        // Filter matching beans
-        const matchingBeans = coffeeData.filter(bean =>
-          bean.Bean.toLowerCase().includes(searchQuery)
+        let matchingBeans = coffeeData.filter((bean) =>
+          bean.Bean.toLowerCase().includes(searchQuery),
         );
 
-        // Store results in local storage
-        localStorage.setItem('searchResults', JSON.stringify(matchingBeans));
+        if (selectedOrigin) {
+          matchingBeans = matchingBeans.filter(
+            (bean) => bean.Origin === selectedOrigin,
+          );
+        }
+        if (selectedRoast) {
+          matchingBeans = matchingBeans.filter(
+            (bean) => bean.Roast === selectedRoast,
+          );
+        }
+        if (selectedTags.length) {
+          matchingBeans = matchingBeans.filter((bean) =>
+            selectedTags.every((tag) => bean.Tags.includes(tag)),
+          );
+        }
+
+        const filters = {
+          query: searchQuery,
+          origin: selectedOrigin,
+          roast: selectedRoast,
+          tags: selectedTags,
+        };
+
+        localStorage.setItem("searchResults", JSON.stringify(matchingBeans));
+        localStorage.setItem("searchFilters", JSON.stringify(filters));
 
         // Redirect to Results Page
-        window.location.href = 'results.html';
+        window.location.href = "results.html";
       });
     </script>
   </body>

--- a/results.html
+++ b/results.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -7,41 +7,53 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-
     <header>
-      <div class="header-box"> <!-- Header Box-->
-        <h1 id="BrewCodeTitle"> <!-- Title-->
+      <div class="header-box">
+        <!-- Header Box-->
+        <h1 id="BrewCodeTitle">
+          <!-- Title-->
           <a href="https://timmoel.github.io/Brewcode/" class="site-title">
             BrewC
-            <img src="https://static.thenounproject.com/png/120176-200.png" alt="Coffee Icon" class="icon">
+            <img
+              src="https://static.thenounproject.com/png/120176-200.png"
+              alt="Coffee Icon"
+              class="icon"
+            />
             de
           </a>
         </h1>
-        <p id="Sub-Title">Brew Your Perfect Cup</p> <!-- Subtitle-->
+        <p id="Sub-Title">Brew Your Perfect Cup</p>
+        <!-- Subtitle-->
       </div>
     </header>
-    
-    
+
     <main>
-      <h2 id="SearchResultsTitle"> Search Results:</h2>
+      <h2 id="SearchResultsTitle">Search Results:</h2>
+      <div id="activeFilters"></div>
       <div id="results"></div>
     </main>
 
     <script>
-      // Load search results from local storage
-      const searchResults = JSON.parse(localStorage.getItem('searchResults')) || [];
+      // Load search results and filters from local storage
+      const searchResults =
+        JSON.parse(localStorage.getItem("searchResults")) || [];
+      const searchFilters =
+        JSON.parse(localStorage.getItem("searchFilters")) || {};
+      document.getElementById("activeFilters").innerHTML =
+        formatFilters(searchFilters);
 
       // Display results
-      const resultsDiv = document.getElementById('results');
+      const resultsDiv = document.getElementById("results");
       if (searchResults.length === 0) {
-        resultsDiv.innerHTML = '<p>No matching beans found. Please try again.</p>';
+        resultsDiv.innerHTML =
+          "<p>No matching beans found. Please try again.</p>";
       } else {
         resultsDiv.innerHTML = searchResults
-          .map(bean => {
+          .map((bean) => {
             const stored = localStorage.getItem(`ratingData_${bean.Bean}`);
             const data = stored ? JSON.parse(stored) : null;
-            const rating = data ? data.average : (bean.AverageRating || 0);
-            const count = data ? data.count : (bean.RatingCount || 0);
+            const rating = data ? data.average : bean.AverageRating || 0;
+            const count = data ? data.count : bean.RatingCount || 0;
             const stars = renderStars(rating);
             return `
             <div class="result-item" onclick="goToBrewGuide('${bean.Bean}')">
@@ -51,14 +63,26 @@
             </div>
           `;
           })
-          .join('');
+          .join("");
+      }
+
+      function formatFilters(filters) {
+        const parts = [];
+        if (filters.query) parts.push(`Query: ${filters.query}`);
+        if (filters.origin) parts.push(`Origin: ${filters.origin}`);
+        if (filters.roast) parts.push(`Roast: ${filters.roast}`);
+        if (filters.tags && filters.tags.length)
+          parts.push(`Tags: ${filters.tags.join(", ")}`);
+        return parts.length
+          ? `<p><strong>Filters:</strong> ${parts.join(" | ")}</p>`
+          : "";
       }
 
       // Render star icons based on rating
       function renderStars(rating) {
-        const full = '★';
-        const empty = '☆';
-        let stars = '';
+        const full = "★";
+        const empty = "☆";
+        let stars = "";
         for (let i = 1; i <= 5; i++) {
           stars += i <= Math.round(rating) ? full : empty;
         }
@@ -67,8 +91,8 @@
 
       // Redirect to Brew Guide Page
       function goToBrewGuide(beanName) {
-        localStorage.setItem('selectedBean', beanName);
-        window.location.href = 'brewguide.html';
+        localStorage.setItem("selectedBean", beanName);
+        window.location.href = "brewguide.html";
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- expand bean data with origin, roast and tag metadata
- add filter UI on the search page
- filter beans using selected criteria and store filters
- display the active filters on the results page

## Testing
- `npx prettier -w index.html results.html data.json`

------
https://chatgpt.com/codex/tasks/task_e_68482dc458d88332851a42ba37564430